### PR TITLE
Use archive URL for pip install

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Start by creating a charm directory with at least the following files:
 Then install the framework into the `lib/` directory using:
 
 ```
-pip install -t lib/ https://github.com/canonical/operator
+pip install -t lib/ https://github.com/canonical/operator/archive/master.tar.gz
 ```
 
 Your `lib/charm.py` is the entry point for your charm logic. At a minimum, it


### PR DESCRIPTION
Using the .tar.gz convention means that pip will be able to
quickly install the package. The bare repo URL isn't understood
by pip and using git+https is slower.